### PR TITLE
allows for props to dynamically update animate-able data

### DIFF
--- a/src/datamap.jsx
+++ b/src/datamap.jsx
@@ -26,7 +26,7 @@ export default React.createClass({
 	},
 
 	componentWillReceiveProps(props) {
-		this.drawMap(this.props);
+		this.drawMap(props);
 	},
 
 	componentWillUnmount() {
@@ -44,7 +44,7 @@ export default React.createClass({
 	drawMap(props) {
 		let newMap = true;
 
-		if (this.mapObject) {
+		if (this.mapObject && !props.height && !props.width) {
 			newMap = false;
 		} else {
 			this.mapObject = new Datamap(Object.assign({}, { ...props }, {

--- a/src/datamap.jsx
+++ b/src/datamap.jsx
@@ -5,7 +5,7 @@ export default React.createClass({
 
 	displayName: 'Datamap',
 
-  mapObject: undefined,
+	mapObject: undefined,
 
 	propTypes: {
 		arc: React.PropTypes.array,
@@ -13,20 +13,20 @@ export default React.createClass({
 		bubbleOptions: React.PropTypes.object,
 		bubbles: React.PropTypes.array,
 		graticule: React.PropTypes.bool,
-    labels: React.PropTypes.bool,
-    resetOnUpdateChoropleth: React.PropTypes.bool
+		labels: React.PropTypes.bool,
+		resetOnUpdateChoropleth: React.PropTypes.bool
 	},
 
-  defaultProps: {
-    resetOnUpdateChoropleth: true
-  },
+	defaultProps: {
+		resetOnUpdateChoropleth: true
+	},
 
 	componentDidMount() {
 		this.drawMap(this.props);
 	},
 
 	componentWillReceiveProps(props) {
-    this.drawMap(this.props);
+		this.drawMap(this.props);
 	},
 
 	componentWillUnmount() {
@@ -42,21 +42,21 @@ export default React.createClass({
 	},
 
 	drawMap(props) {
-    let newMap = true;
+		let newMap = true;
 
-    if (this.mapObject) {
-      newMap = false;
-    } else {
-      this.mapObject = new Datamap(Object.assign({}, { ...props }, {
-        element: this.refs.container
-      }));
-    }
+		if (this.mapObject) {
+			newMap = false;
+		} else {
+			this.mapObject = new Datamap(Object.assign({}, { ...props }, {
+				element: this.refs.container
+			}));
+		}
 
-    if (props.data && !newMap) {
-      this.mapObject.updateChoropleth(props.data, {
-        reset: props.resetOnUpdateChoropleth
-      })
-    }
+		if (props.data && !newMap) {
+			this.mapObject.updateChoropleth(props.data, {
+				reset: props.resetOnUpdateChoropleth
+			})
+		}
 
 		if (props.arc) {
 			this.mapObject.arc(props.arc, props.arcOptions);

--- a/src/datamap.jsx
+++ b/src/datamap.jsx
@@ -26,7 +26,16 @@ export default React.createClass({
 	},
 
 	componentWillReceiveProps(props) {
-		this.drawMap(props);
+		let newProps = {}
+
+		// filters down to just new props.
+		for (var key in props) {
+			if (props[key] !== this.props[key]) {
+				newProps[key] = props[key]
+			}
+		}
+
+		this.drawMap(newProps);
 	},
 
 	componentWillUnmount() {
@@ -47,6 +56,7 @@ export default React.createClass({
 		if (this.mapObject && !props.height && !props.width) {
 			newMap = false;
 		} else {
+			this.clear();
 			this.mapObject = new Datamap(Object.assign({}, { ...props }, {
 				element: this.refs.container
 			}));

--- a/src/datamap.jsx
+++ b/src/datamap.jsx
@@ -5,25 +5,28 @@ export default React.createClass({
 
 	displayName: 'Datamap',
 
+  mapObject: undefined,
+
 	propTypes: {
 		arc: React.PropTypes.array,
 		arcOptions: React.PropTypes.object,
 		bubbleOptions: React.PropTypes.object,
 		bubbles: React.PropTypes.array,
 		graticule: React.PropTypes.bool,
-		labels: React.PropTypes.bool
+    labels: React.PropTypes.bool,
+    resetOnUpdateChoropleth: React.PropTypes.bool
 	},
+
+  defaultProps: {
+    resetOnUpdateChoropleth: true
+  },
 
 	componentDidMount() {
-		this.drawMap();
+		this.drawMap(this.props);
 	},
 
-	componentWillReceiveProps() {
-		this.clear();
-	},
-
-	componentDidUpdate() {
-		this.drawMap();
+	componentWillReceiveProps(props) {
+    this.drawMap(this.props);
 	},
 
 	componentWillUnmount() {
@@ -38,25 +41,37 @@ export default React.createClass({
 		}
 	},
 
-	drawMap() {
-		const map = new Datamap(Object.assign({}, { ...this.props }, {
-			element: this.refs.container
-		}));
+	drawMap(props) {
+    let newMap = true;
 
-		if (this.props.arc) {
-			map.arc(this.props.arc, this.props.arcOptions);
+    if (this.mapObject) {
+      newMap = false;
+    } else {
+      this.mapObject = new Datamap(Object.assign({}, { ...props }, {
+        element: this.refs.container
+      }));
+    }
+
+    if (props.data && !newMap) {
+      this.mapObject.updateChoropleth(props.data, {
+        reset: props.resetOnUpdateChoropleth
+      })
+    }
+
+		if (props.arc) {
+			this.mapObject.arc(props.arc, props.arcOptions);
 		}
 
-		if (this.props.bubbles) {
-			map.bubbles(this.props.bubbles, this.props.bubbleOptions);
+		if (props.bubbles) {
+			this.mapObject.bubbles(props.bubbles, props.bubbleOptions);
 		}
 
-		if (this.props.graticule) {
-			map.graticule();
+		if (props.graticule) {
+			this.mapObject.graticule();
 		}
 
-		if (this.props.labels) {
-			map.labels();
+		if (props.labels) {
+			this.mapObject.labels();
 		}
 	},
 


### PR DESCRIPTION
using this on a project I'm working on
- saves the d3 datamap in memory to the react component class so it can be re-used if needed
- allows for prop changes on bubbles or data to be animated
- adds prop for `reset` option on data updates using `updateChloropeth`
- redraws map on height or width changes as these can't be done w/n the existing datamap
